### PR TITLE
RESTRICT AUTOMERGE FRP bypass defense in App battery usage page

### DIFF
--- a/src/com/android/settings/fuelgauge/AdvancedPowerUsageDetail.java
+++ b/src/com/android/settings/fuelgauge/AdvancedPowerUsageDetail.java
@@ -269,6 +269,11 @@ public class AdvancedPowerUsageDetail extends DashboardFragment
     }
 
     @Override
+    protected boolean shouldSkipForInitialSUW() {
+        return true;
+    }
+
+    @Override
     public void onPause() {
         super.onPause();
 

--- a/tests/robotests/src/com/android/settings/fuelgauge/AdvancedPowerUsageDetailTest.java
+++ b/tests/robotests/src/com/android/settings/fuelgauge/AdvancedPowerUsageDetailTest.java
@@ -472,4 +472,9 @@ public class AdvancedPowerUsageDetailTest {
 
         verify(mObserver).onChanged(ChangeReason.UPDATE);
     }
+
+    @Test
+    public void shouldSkipForInitialSUW_returnTrue() {
+        assertThat(mFragment.shouldSkipForInitialSUW()).isTrue();
+    }
 }


### PR DESCRIPTION
Before the setup flow completion, don't allow the app info page in App battery usage to be launched.

Bug: 327748846
Test: atest SettingsRoboTests + manual test
- factory reset + launch app battery usage app info via ADB during Setup -> verify app closes Flag : EXEMPT bugfix

(cherry picked from commit 419a6a907902a12a0f565c808fa70092004d6686) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:46724de1a273aa4110e0f645750eb48646b4546a) Merged-In: I486820ca2afecc02729a56a3c531fb931c1907d0 Change-Id: I486820ca2afecc02729a56a3c531fb931c1907d0